### PR TITLE
Add Microsoft SQL Server support

### DIFF
--- a/calaccess_campaign_browser/management/commands/exportcalaccesscampaignbrowser.py
+++ b/calaccess_campaign_browser/management/commands/exportcalaccesscampaignbrowser.py
@@ -77,7 +77,7 @@ class Command(CalAccessCommand):
         self.header('  Exporting {} model ...'.format(model_name.capitalize()))
 
         with open(filepath, 'wb') as csvfile:
-            writer = csv.writer(csvfile, delimiter=",")
+            writer = csv.writer(csvfile, delimiter="\t")
             writer.writerow(fieldnames)
 
             if model_name != 'summary':

--- a/calaccess_campaign_browser/management/commands/exporttosqlserver.py
+++ b/calaccess_campaign_browser/management/commands/exporttosqlserver.py
@@ -1,0 +1,216 @@
+import os
+import csv
+from optparse import make_option
+from collections import OrderedDict
+
+import pypyodbc
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+contributions_header = OrderedDict([
+    ('amount', 'amount'),
+    ('filing_id', 'filing_id'),
+    ('committee__name', 'committee_name'),
+    ('cycle_id', 'cycle'),
+    ('date_received', 'date_received'),
+    ('contributor_first_name', 'contributor_first_name'),
+    ('contributor_last_name', 'contributor_last_name'),
+    ('contributor_full_name', 'contributor_full_name'),
+    ('contributor_occupation', 'contributor_occupation'),
+    ('contributor_employer', 'contributor_employer'),
+    ('contributor_address_1', 'contributor_address_1'),
+    ('contributor_address_2', 'contributor_address_2'),
+    ('contributor_city', 'contributor_city'),
+    ('contributor_state', 'contributor_state'),
+    ('contributor_zipcode', 'contributor_zipcode'),
+])
+
+expenditures_header = OrderedDict([
+    ('amount', 'amount'),
+    ('filing_id', 'filing_id'),
+    ('committee__name', 'committee_name'),
+    ('cycle_id', 'cycle'),
+    ('expn_date', 'date_received'),
+    ('payee_namf', 'payee_first_name'),
+    ('payee_naml', 'payee_last_name'),
+    ('name', 'payee_full_name'),
+    ('payee_namt', 'payee_occupation'),
+    ('raw_org_name', 'payee_employer'),
+    ('payee_adr1', 'payee_address_1'),
+    ('payee_adr2', 'payee_address_2'),
+    ('payee_city', 'payee_city'),
+    ('payee_st', 'payee_state'),
+    ('payee_zip4', 'payee_zipcode'),
+])
+
+summary_header = OrderedDict([
+    # ('committee__filer__name', 'filer'),
+    # ('committee__filer__filer_id', 'filer_id'),
+    # ('committee__name', 'committee'),
+    # ('committee__filer_id_raw', 'committee_id'),
+    # ('cycle__name', 'cycle'),
+    ('ending_cash_balance', 'ending_cash_balance'),
+    ('filing_id_raw', 'filing_id'),
+    ('amend_id', 'amend_id'),
+    # ('filing__start_date', 'filing_start_date'),
+    # ('filing__end_date', 'filing_end_date'),
+    ('itemized_expenditures', 'itemized_expenditures'),
+    (
+        'itemized_monetary_contributions',
+        'itemized_monetary_contributions'
+    ),
+    ('non_monetary_contributions', 'non_monetary_contributions'),
+    ('outstanding_debts', 'outstanding_debts'),
+    ('total_contributions', 'total_contributions'),
+    ('total_expenditures', 'total_expenditures'),
+    ('total_monetary_contributions', 'total_monetary_contributions'),
+    ('unitemized_expenditures', 'unitemized_expenditures'),
+    (
+        'unitemized_monetary_contributions',
+        'unitemized_monetary_contributions'
+    ),
+])
+
+custom_options = (
+    make_option(
+        "--skip-contributions",
+        action="store_false",
+        dest="contributions",
+        default=True,
+        help="Skip contributions import"
+    ),
+    make_option(
+        "--skip-expenditures",
+        action="store_false",
+        dest="expenditures",
+        default=True,
+        help="Skip expenditures import"
+    ),
+    make_option(
+        "--skip-summary",
+        action="store_false",
+        dest="summary",
+        default=True,
+        help="Skip summary import"
+    ),
+)
+
+
+class Command(BaseCommand):
+    help = 'descriptive text'
+    option_list = BaseCommand.option_list + custom_options
+    connection_path = (
+        'Driver=%s;Server=%s;port=%s;uid=%s;pwd=%s;database=%s;autocommit=1'
+    ) % (
+        settings.SQL_SERVER_DRIVER,
+        settings.SQL_SERVER_ADDRESS,
+        settings.SQL_SERVER_PORT,
+        settings.SQL_SERVER_USER,
+        settings.SQL_SERVER_PASSWORD,
+        settings.SQL_SERVER_DATABASE
+    )
+
+    connection = pypyodbc.connect(connection_path)
+
+    cursor = connection.cursor()
+
+    def handle(self, *args, **options):
+        sql_contributions = '''
+            CREATE TABLE [dbo].[new_contributions] (
+                [amount] decimal(14,2),
+                [filing_id] int,
+                [committee_name] nvarchar(600),
+                [cycle] int,
+                [date_received] date,
+                [contributor_first_name] nvarchar(255),
+                [contributor_last_name] nvarchar(600),
+                [contributor_full_name] nvarchar(50),
+                [contributor_occupation] nvarchar(50),
+                [contributor_employer] nvarchar(60),
+                [contributor_address_1] nvarchar(55),
+                [contributor_address_2] nvarchar(55),
+                [contributor_city] nvarchar(50),
+                [contributor_state] nvarchar(90),
+                [contributor_zipcode] nvarchar(200)
+        )
+        '''
+
+        sql_expenditures = '''
+            CREATE TABLE [dbo].[new_expenditures] (
+                [amount] decimal(14,2),
+                [filing_id] int,
+                [committee_name] nvarchar(600),
+                [cycle] int,
+                [date_received] date,
+                [payee_first_name] nvarchar(255),
+                [payee_last_name] nvarchar(600),
+                [payee_full_name] nvarchar(50),
+                [payee_occupation] nvarchar(50),
+                [payee_employer] nvarchar(60),
+                [payee_address_1] nvarchar(55),
+                [payee_address_2] nvarchar(55),
+                [payee_city] nvarchar(50),
+                [payee_state] nvarchar(90),
+                [payee_zipcode] nvarchar(200)
+            )
+        '''
+
+        if options['contributions']:
+            self.construct_tables('contributions', sql_contributions)
+
+            self.load_tables('contributions')
+        if options['expenditures']:
+            self.construct_tables('expenditures', sql_expenditures)
+
+            self.load_tables('expenditures')
+
+    def construct_tables(self, table_name, query):
+        drop_path = "IF object_id('dbo.new_%s') \
+        IS NOT NULL DROP TABLE new_%s" % (table_name, table_name)
+
+        self.cursor.execute(drop_path)
+
+        self.cursor.execute(query)
+
+        self.cursor.commit()
+
+    def load_tables(self, table_name):
+        self.cursor.execute('DELETE FROM new_%s' % table_name)
+        # path to data dir
+        path = os.path.join(settings.BASE_DIR, 'data', '%s.csv') % table_name
+        infile = open(path)
+
+        csv_reader = csv.reader(infile, delimiter=',')
+
+        csv_reader.next()  # skip headers
+
+        for line in csv_reader:
+            line = [l.replace("'", "''") for l in line]
+
+            if table_name == 'contributions':
+                headers = ','.join(contributions_header.values())
+            elif table_name == 'expenditures':
+                headers = ','.join(expenditures_header.values())
+            else:
+                pass
+
+            insert_sql = '''
+                INSERT INTO new_%s(%s)
+                VALUES ('%s', '%s', '%s', '%s', '%s', \
+                    '%s', '%s', '%s', '%s', '%s', '%s', \
+                    '%s', '%s', '%s', '%s')
+            '''.format(
+                table_name, headers, line[0].strip(), line[1].strip(),
+                line[2].strip(), line[3].strip(), line[4].strip(),
+                line[5].strip(), line[6].strip(), line[7].strip(),
+                line[8].strip(), line[9].strip(), line[10].strip(),
+                line[11].strip(), line[12].strip(), line[13].strip(),
+                line[14].strip()
+            )
+
+            self.cursor.execute(insert_sql)
+            print csv_reader.line_num
+
+        infile.close()
+        self.cursor.commit()

--- a/calaccess_campaign_browser/management/commands/importtosqlserver.py
+++ b/calaccess_campaign_browser/management/commands/importtosqlserver.py
@@ -2,11 +2,9 @@ import os
 import re
 import csv
 import fnmatch
-import datetime
 from optparse import make_option
 
 import pypyodbc
-from ipdb import set_trace as debugger
 
 from django.conf import settings
 from django.db import connection
@@ -39,6 +37,7 @@ custom_options = (
     ),
 )
 
+
 def all_files(root, patterns='*', single_level=False, yield_folders=False):
     """
     Expand patterns form semicolon-separated string to list
@@ -60,6 +59,7 @@ def all_files(root, patterns='*', single_level=False, yield_folders=False):
 
         if single_level:
             break
+
 
 class Command(CalAccessCommand):
     """
@@ -94,14 +94,10 @@ class Command(CalAccessCommand):
         """
         self.log('  Creating database schema for {} ...'.format(model_name))
         style = self.app.style
-        today = datetime.datetime.today()
 
         model = get_model('calaccess_campaign_browser', model_name)
 
         table_name = 'dbo.{}'.format(model._meta.db_table)
-
-        fieldnames = [f.name for f in model._meta.fields] + [
-            'committee_name', 'filer_name', 'filer_id', 'filer_id_raw']
 
         raw_statement = connection.creation\
             .sql_create_model(model, style)[0][0]
@@ -110,7 +106,7 @@ class Command(CalAccessCommand):
         ansi_escape = re.compile(r'\x1b[^m]*m')
         strip_ansi_statement = (ansi_escape.sub('', raw_statement))
         statement = strip_ansi_statement.replace('\n', '')\
-            .replace('`','')\
+            .replace('`', '')\
             .replace('bool', 'bit')\
             .replace(' AUTO_INCREMENT', '')\
             .replace(model._meta.db_table, table_name)\
@@ -176,7 +172,8 @@ class Command(CalAccessCommand):
                     self.log('      loading {} ID:{} ...'.format(
                         model_name, row[0]))
                 except pypyodbc.Error, e:
-                    debugger()
+                    self.failure('      Encountered an arror')
+                    raise e
 
             self.cursor.commit()
             self.success('    Loaded {} with data from {}'.format(

--- a/calaccess_campaign_browser/management/commands/importtosqlserver.py
+++ b/calaccess_campaign_browser/management/commands/importtosqlserver.py
@@ -6,7 +6,8 @@ from collections import OrderedDict
 import pypyodbc
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+
+from calaccess_campaign_browser.management.commands import CalAccessCommand
 
 contributions_header = OrderedDict([
     ('amount', 'amount'),
@@ -97,9 +98,12 @@ custom_options = (
 )
 
 
-class Command(BaseCommand):
-    help = 'descriptive text'
-    option_list = BaseCommand.option_list + custom_options
+class Command(CalAccessCommand):
+    """
+    Send CSVs exported from `exportcalaccesscampaignbrowser` to
+    Microsoft SQL Server
+    """
+    option_list = CalAccessCommand.option_list + custom_options
     connection_path = (
         'Driver=%s;Server=%s;port=%s;uid=%s;pwd=%s;database=%s;autocommit=1'
     ) % (

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Documentation
    models
    howtocontribute
    exportingthedata
+   sqlserver
    changelog
 
 Open-source resources

--- a/docs/sqlserver.rst
+++ b/docs/sqlserver.rst
@@ -1,12 +1,87 @@
-Pushing to SQL Server
-=====================
+Importing to Microsoft SQL Server
+===============================
 
-Add to settings:
+This walkthough will show you how to import the exported CSV data to `Microsoft SQL Server <http://www.microsoft.com/en-us/server-cloud/products/sql-server/>`_. This guide assumes you already have SQL server installed and running.
+
+First build the browser and export the tables:
+
+.. code-block:: bash
+
+    $ python manage.py buildcalaccesscampaignbrowser
+    $ python manage.py exportcalaccesscampaignbrowser
+
+Setting up pypyodbc
+-------------------
+In order to connect to SQL Server from the application, we'll need to install `pypyodbc <https://github.com/jiangwen365/pypyodbc>`_, an `open database connectivity` library that allows Python to communicate with multiple databases.
+
+Installation is simple:
+
+.. code-block:: bash
+
+    $ pip install pypyodbc
+
+---------------------------
+Configure ODBC and Free TDS
+---------------------------
+You'll need to install ODBC and configure its database drivers.
+
+**Mac OS X** users can install ODBC and Free TDS with homebrew:
+
+**`Note:` This has not been tested and should be considered provisional**
+
+.. code-block:: bash
+
+    $ brew install unixodbc
+    $ brew install freetds
+
+**Linux** users can follow these instructions are from `the project wiki <https://code.google.com/p/pypyodbc/wiki/Linux_ODBC_in_3_steps>`_:
+
+1. Install ODBC and Free TDS
+
+.. code-block:: bash
+
+    $ sudo apt-get install tdsodbc unixodbc
+
+2. Modify ``/etc/odbcinst.ini``
+
+**From the wiki**: "If ``odbcinst.ini`` doesn't exist under /etc, create the file. Find the path to ``libtdsodbc.so``. If the path to the file is ``/usr/lib/x86_64-linux-gnu/libtdsodbc.so``, make sure you have the below content in the file:"
+
+.. code-block:: bash
+
+    [FreeTDS]
+    Driver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
+
+3. Modify /etc/freetds/freetds.conf
+
+**From the wiki**: "Make sure there are following lines under the "Global" section in the file:"
+
+.. code-block:: bash
+
+    [Global]
+    TDS_Version = 8.0
+    client charset = UTF-8
 
 
-SQL_SERVER_DRIVER
-SQL_SERVER_ADDRESS
-SQL_SERVER_PORT
-SQL_SERVER_USER
-SQL_SERVER_PASSWORD
-SQL_SERVER_DATABASE
+Connecting to the server
+------------------------
+
+Next, you'll need to add the SQL server variables to your ``settings.py``. Since this will contain sensitive information, we suggest storing these variables in a ``local_settings.py`` file that's not tracked by version control and importing it.
+
+.. code-block:: python
+
+    SQL_SERVER_DRIVER = ''  # Use 'FreeTDS' if you followed instructions above
+    SQL_SERVER_ADDRESS = ''  # Your SQL Server IP address
+    SQL_SERVER_PORT = ''  # Your SQL Server port number
+    SQL_SERVER_USER = ''  # Your SQL server username
+    SQL_SERVER_PASSWORD = ''  # Your SQL server password
+    SQL_SERVER_DATABASE = '' # Your SQL server database name
+
+
+Import data into SQL Server
+---------------------------
+
+With the above configuration, you should now be able to import the exported CSV data from your local folder to SQL server:
+
+.. code-block:: bash
+
+    $ python manage.py importtosqlserver


### PR DESCRIPTION
This PR adds the `importtosqlserver` management command, which allows users to import exported data from `exportcalaccesscampaignbrowser` to Microsoft SQL Server. This has been tested on Ubuntu Linux 14.04 and Microsoft SQL Server 2014. 

Basic docs are also included for the command. Closes #174 