### PR TITLE
creating a names and identities table

### DIFF
--- a/calaccess_campaign_browser/management/commands/buildcalaccesscampaignbrowser.py
+++ b/calaccess_campaign_browser/management/commands/buildcalaccesscampaignbrowser.py
@@ -10,8 +10,14 @@ class Command(CalAccessCommand):
         call_command("loadcalaccesscampaignfilers")
         call_command("loadcalaccesscampaignfilings")
         call_command("loadcalaccesscampaignsummaries")
+        # call_command("loadcalaccesscampaignnames")
         call_command("loadcalaccesscampaigncontributions")
         call_command("loadcalaccesscampaignexpenditures")
         call_command("scrapecalaccesscampaigncandidates")
         call_command("scrapecalaccesscampaignpropositions")
+        #
+        # Optional
+        #
+        # call_command("loadcalaccesscampaignnames")
+        #
         self.success("Done!")

--- a/calaccess_campaign_browser/management/commands/loadcalaccesscampaignnames.py
+++ b/calaccess_campaign_browser/management/commands/loadcalaccesscampaignnames.py
@@ -1,0 +1,185 @@
+from optparse import make_option
+from django.db import connection
+from django.db.models import get_model
+from django.db.utils import OperationalError
+from django.core.management.base import LabelCommand
+from calaccess_campaign_browser.management.commands import CalAccessCommand
+
+
+def concat_stm(pref, idxs):
+    parts = []
+    if idxs[0] == 1:
+        parts.append('%s_NAMT' % pref)
+    if idxs[1] == 1:
+        parts.append('%s_NAMF' % pref)
+    if idxs[2] == 1:
+        parts.append('%s_NAML' % pref)
+    if idxs[3] == 1:
+        parts.append('%s_NAMS' % pref)
+    return 'concat(%s)' % ", ' ', ".join(parts)
+
+
+def where_stm(pref, idxs):
+    parts = []
+    if idxs[0] == 1:
+        parts.append("%s_NAMT != ''" % pref)
+    else:
+        parts.append("%s_NAMT = ''" % pref)
+    if idxs[1] == 1:
+        parts.append("%s_NAMF != ''" % pref)
+    else:
+        parts.append("%s_NAMF = ''" % pref)
+    if idxs[2] == 1:
+        parts.append("%s_NAML != ''" % pref)
+    else:
+        parts.append("%s_NAML = ''" % pref)
+    if idxs[3] == 1:
+        parts.append("%s_NAMS != ''" % pref)
+    else:
+        parts.append("%s_NAMS = ''" % pref)
+    return ' and '.join(parts)
+
+
+def despace(str):
+    while str.find('  ') >= 0:
+        str = str.replace('  ', ' ')
+    return str
+
+
+# TODO: generate a list of the digits of numbers
+# from 1 to 15 in binary.
+#
+indexes_list = [
+    [0,0,0,1],
+    [0,0,1,0],
+    [0,0,1,1],
+    [0,1,0,0],
+    [0,1,0,1],
+    [0,1,1,0],
+    [0,1,1,1],
+    [1,0,0,0],
+    [1,0,0,1],
+    [1,0,1,0],
+    [1,0,1,1],
+    [1,1,0,0],
+    [1,1,0,1],
+    [1,1,1,0],
+    [1,1,1,1]
+]
+
+
+class Command(CalAccessCommand):
+    help = "Load CAL-ACCESS names"
+
+    option_list = LabelCommand.option_list + (
+        make_option(
+            '--only-tables',
+            dest="only_tables",
+            help="Select only a limited set of tables to process."
+        ),
+        make_option(
+            '--pre-delete',
+            dest="pre_delete",
+            help="Delete values from tables being processed before processing."
+        ),
+    )
+
+    def handle(self, *args, **options):
+        self.header("Loading names")
+
+        only_tables = options['only_tables']
+        pre_delete = options['pre_delete']
+
+        # TODO: get this dict automatically by iterating through
+        # the tables, finding columns that end in '_NAML' and getting
+        # the prefixes from them.
+        #
+        prefixes = dict([
+            ('CvrCampaignDisclosureCd', ['filer', 'tres', 'cand']),
+            ('CvrE530Cd', ['filer', 'cand']),
+            ('CvrLobbydisclosureCd', ['filer', 'sig', 'prn', 'major']),
+            ('CvrRegistrationCd', ['filer', 'sig', 'prn']),
+            ('CvrSoCd', ['filer', 'tres']),
+            ('Cvr2CampaignDisclosureCd', ['enty', 'tres']),
+            ('Cvr2LobbyDisclosureCd', ['enty']),
+            ('Cvr2RegistrationCd', ['enty']),
+            ('Cvr2SoCd', ['enty']),
+            ('Cvr3VerificationInfoCd', ['sig']),
+            ('DebtCd', ['payee', 'tres']),
+            ('ExpnCd', ['payee', 'agent', 'tres', 'cand']),
+            ('F501502Cd', ['cand', 'fin']),
+            ('LattCd', ['recip']),
+            ('LccmCd', ['recip', 'ctrib']),
+            ('LempCd', ['cli']),
+            ('LexpCd', ['payee']),
+            ('LoanCd', ['lndr', 'tres', 'intr']),
+            ('LobbyAmendmentsCd', ['a_l', 'd_l', 'a_le', 'd_le']),
+            ('LothCd', ['subj']),
+            ('LpayCd', ['emplr']),
+            ('RcptCd', ['ctrib', 'tres', 'intr', 'cand']),
+            ('S401Cd', ['agent', 'payee', 'cand']),
+            ('S497Cd', ['enty', 'cand']),
+            ('S498Cd', ['payor', 'cand'])])
+
+        tables = prefixes.keys()
+
+        if only_tables is not None:
+            tables = list(set(tables).intersection(set(only_tables.split(','))))
+
+        self.success('    tables: %s' % tables)
+
+        tables_left = tables;
+
+        for table in tables:
+
+            target_table = str(get_model('calaccess_campaign_browser', 'Name')._meta.db_table)
+            big_table = str(get_model('calaccess_raw', table)._meta.db_table)
+
+            self.success('    table %s: %s' % (table, prefixes[table]))
+
+            c = connection.cursor()
+
+            if pre_delete:
+                sql = "delete from %s where ext_table = '%s'" % (target_table, table)
+
+                try:
+                    c.execute(sql)
+                except OperationalError:
+                    self.failure('BAD SQL: %s' % sql)
+                    self.failure('tables left: %s' % tables_left)
+                    exit()
+
+            for prefix in prefixes[table]:
+                self.success('    current prefix: %s' % prefix)
+
+                prefix = prefix.upper()
+
+                for indexes in indexes_list:
+                    sql = """
+                        insert into %s
+                        (ext_pk, ext_table, ext_prefix, namt, namf, naml, nams, name)
+                        select id, '%s', '%s', %s_NAMT, %s_NAMF, %s_NAML, %s_NAMS,
+                               %s
+                        from %s
+                        where %s
+                        """ % (target_table,
+                               table,
+                               prefix.lower(),
+                               prefix, prefix, prefix, prefix,
+                               concat_stm(prefix,indexes),
+                               big_table,
+                               where_stm(prefix,indexes))
+                        
+                    sql = despace(sql).strip()
+
+                    self.success('      %s' % indexes)
+                    try:
+                        c.execute(sql)
+                    except OperationalError:
+                        self.failure('BAD SQL: %s' % sql)
+                        self.failure('tables left: %s' % tables_left)
+                        exit()
+
+            c.close()
+
+            tables_left.remove(table)

--- a/calaccess_campaign_browser/models/__init__.py
+++ b/calaccess_campaign_browser/models/__init__.py
@@ -7,7 +7,7 @@ from elections import (
     PropositionFiler
 )
 from expenditures import Expenditure
-from filers import Filer, Committee
+from filers import Filer, Committee, Name, Identity
 from filings import Filing, Cycle, FilingPeriod, Summary
 
 __all__ = (
@@ -23,5 +23,7 @@ __all__ = (
     'Filing',
     'Cycle',
     'FilingPeriod',
-    'Summary'
+    'Summary',
+    'Name',
+    'Identity'
 )

--- a/calaccess_campaign_browser/models/filers.py
+++ b/calaccess_campaign_browser/models/filers.py
@@ -92,6 +92,43 @@ class Filer(AllCapsNameMixin):
         ])
 
 
+class Name(AllCapsNameMixin):
+    """
+    Something that is named, with the key to link the name back to the
+    originating table. From this we may be able to derive identities and
+    disambiguate names found in the filings.
+    """
+    ext_pk = models.IntegerField(db_index=True)
+    ext_table = models.CharField(max_length=255)
+    ext_prefix = models.CharField(max_length=255)
+    naml = models.CharField(max_length=255, null=True)
+    namf = models.CharField(max_length=255, null=True)
+    nams = models.CharField(max_length=255, null=True)
+    namt = models.CharField(max_length=255, null=True)
+    name = models.CharField(max_length=1023, null=True)
+    prob_people = models.NullBooleanField(
+        help_text='Identified as probably a person by the library at \
+https://github.com/datamade/probablepeople'
+    )
+    identity_id = models.IntegerField(db_index=True)
+
+    class Meta:
+        app_label = 'calaccess_campaign_browser'
+
+    def __unicode__(self):
+        return unicode(self.name)
+
+
+class Identity(AllCapsNameMixin):
+    name = models.CharField(max_length=1023)
+
+    class Meta:
+        app_label = 'calaccess_campaign_browser'
+
+    def __unicode__(self):
+        return unicode(self.name)
+
+
 class Committee(AllCapsNameMixin):
     """
     If a Candidate controls the committee, the filer is associated with the


### PR DESCRIPTION
Not yet ready to merge, but I thought it worth sharing. The filling of the names table actually happens in a reasonable amount of time.

I was creating a "name" column by using concat() on namt, ' ', namf, ' ', naml, ' ', nams. It was amazingly hard to figure out a quick way to get double spaces out of just under 20 million rows. So, I am not doing that. I have 4 things that could be equal to '' or not equal to ''. So, I do a filter on each of the 15 combinations of those values. This is the count of all combinations of the four, minus the one where:
```
namt = '' and namf = '' and naml = '' and nams = ''
```
I am now running a single SQL statement to fill the identities table with the distinct values of the name column from the names table. That is actually quick to do.

And now I am running a single SQL statement to join the rows in the identity table and names table that are identical. The single-statement form of that is taking forrrrrrrrrever.
