### PR TITLE
Fixed broken link to MySQL OSX Install

### DIFF
--- a/docs/howtocontribute.rst
+++ b/docs/howtocontribute.rst
@@ -34,7 +34,7 @@ Move into the repository and install the Python dependencies.
     $ pip install -r requirements_dev.txt
 
 Make sure you have MySQL installed. If you don't, now is the time to hit Google and figure out how. If
-you're using Apple's OSX operating system, you can `install via Homebrew <http://thisdotlife.com/2013/05/30/how-to-install-mysql-on-mac-os-x-using-homebrew-tutorial/>`_. If you need to clean up after a previous MySQL installation, `this might help <http://stackoverflow.com/questions/4359131/brew-install-mysql-on-mac-os/6378429#6378429>`_.
+you're using Apple's OSX operating system, you can `install via Homebrew <http://blog.joefallon.net/2013/10/install-mysql-on-mac-osx-using-homebrew/>`_. If you need to clean up after a previous MySQL installation, `this might help <http://stackoverflow.com/questions/4359131/brew-install-mysql-on-mac-os/6378429#6378429>`_.
 
 Then create a new database named ``calaccess``.
 


### PR DESCRIPTION
The tutorial that was linked no longer exists so I found another one.