### PR TITLE
Fix buildcalaccesscampaignbrowser integrity errors with MySQL on OSX

### DIFF
--- a/calaccess_campaign_browser/management/commands/loadcalaccesscampaigncontributions.py
+++ b/calaccess_campaign_browser/management/commands/loadcalaccesscampaigncontributions.py
@@ -306,7 +306,27 @@ class Command(CalAccessCommand):
                 contributor_occupation,
                 contributor_employer,
                 contributor_selfemployed,
-                contributor_entity_type
+                contributor_entity_type,
+                backreference_transaction_id,
+                is_crossreference,
+                crossreference_schedule,
+                transaction_type,
+                contribution_description,
+                contributor_address_1,
+                contributor_address_2,
+                intermediary_address_1,
+                intermediary_address_2,
+                intermediary_city,
+                intermediary_committee_id,
+                intermediary_employer,
+                intermediary_first_name,
+                intermediary_last_name,
+                intermediary_occupation,
+                intermediary_prefix,
+                intermediary_selfemployed,
+                intermediary_state,
+                intermediary_suffix,
+                intermediary_zipcode
             )
             SELECT
                 f.cycle_id as cycle_id,
@@ -337,7 +357,27 @@ class Command(CalAccessCommand):
                 r.ctrib_occ,
                 r.ctrib_emp,
                 r.ctrib_self,
-                r.entity_cd
+                r.entity_cd,
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                ''
             FROM %(filing_model)s as f
             INNER JOIN %(raw_model)s as r
             ON f.filing_id_raw = r.filing_id

--- a/calaccess_campaign_browser/management/commands/loadcalaccesscampaigncontributions.py
+++ b/calaccess_campaign_browser/management/commands/loadcalaccesscampaigncontributions.py
@@ -150,7 +150,7 @@ class Command(CalAccessCommand):
         OUTHEADERS.append("IS_DUPLICATE")
 
         self.log("   Marking duplicates in a new CSV")
-        with open(self.late_tmp_csv, 'r') as fin:
+        with open(self.late_tmp_csv, 'rU') as fin:
             fout = csv.DictWriter(
                 open(self.late_target_csv, 'wb'),
                 fieldnames=OUTHEADERS
@@ -503,7 +503,7 @@ class Command(CalAccessCommand):
         OUTHEADERS.append("IS_DUPLICATE")
 
         self.log("   Marking duplicates in a new CSV")
-        with open(self.quarterly_tmp_csv, 'r') as fin:
+        with open(self.quarterly_tmp_csv, 'rU') as fin:
             fout = csv.DictWriter(
                 open(self.quarterly_target_csv, 'wb'),
                 fieldnames=OUTHEADERS

--- a/calaccess_campaign_browser/management/commands/loadcalaccesscampaignexpenditures.py
+++ b/calaccess_campaign_browser/management/commands/loadcalaccesscampaignexpenditures.py
@@ -374,7 +374,8 @@ class Command(CalAccessCommand):
                 payee_suffix,
                 payee_city,
                 payee_state,
-                payee_zipcode
+                payee_zipcode,
+                payee_committee_id
             )
             SELECT
                 f.cycle_id as cycle_id,
@@ -410,7 +411,8 @@ class Command(CalAccessCommand):
                 COALESCE(e.payee_nams, ''),
                 COALESCE(e.payee_city, ''),
                 COALESCE(e.payee_st, ''),
-                COALESCE(e.payee_zip4, '')
+                COALESCE(e.payee_zip4, ''),
+                ''
             FROM %(filing_model)s as f
             INNER JOIN %(raw_model)s as e
             ON f.filing_id_raw = e.filing_id


### PR DESCRIPTION
Loads `Contribution` and `Expenditure` fields not included in merged models as blank strings. This appears to fix #132 for me; I can run `buildcalaccesscampaignbrowser` with no errors.

Also fixes a `new-line character seen in unquoted field - do you need to open the file in universal-newline mode?` error I encounter when [investigating](https://github.com/california-civic-data-coalition/django-calaccess-campaign-browser/issues/132#issuecomment-118428551) #132.

### todo
* Determine why `blank=True` and `default=''` didn't appear to be recognized in my case (and @jjelosua). AFAIK #132 could not be reproduced outside of our OSX machines.